### PR TITLE
Added LeRobot Episode Scoring Toolkit to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated collection of utilities for [LeRobot Projects](https://github.com/hugg
 - [Physical AI Tools](https://github.com/ROBOTIS-GIT/physical_ai_tools): Physical AI Development Interface with LeRobot and ROS 2 [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/ROBOTIS-GIT/physical_ai_tools">](https://github.com/ROBOTIS-GIT/physical_ai_tools)
 - [LeRobot.js](https://github.com/TimPietrusky/lerobot.js): interact with your robot in JS, inspired by LeRobot [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/TimPietrusky/lerobot.js">](https://github.com/TimPietrusky/lerobot.js)
 - [LeLab](https://github.com/nicolas-rabault/leLab): A web UI interface on top of lerobot [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/nicolas-rabault/leLab">](https://github.com/nicolas-rabault/leLab)
+- [LeRobot Episode Scoring Toolkit](https://github.com/RoboticsData/score_lerobot_episodes): One-click tool to score, filter, and export higher-quality LeRobot datasets [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/RoboticsData/score_lerobot_episodes">](https://github.com/RoboticsData/score_lerobot_episodes)
 
 ## 👷‍♂️ Contributing
 


### PR DESCRIPTION
# What does this PR do?

This PR adds the LeRobot Episode Scoring Toolkit to README.md

---
*Details:*

Tool for scoring lerobot episodes by various heuristics.
https://github.com/RoboticsData/score_lerobot_episodes

*Motivation*
It is difficult to identify low quality training examples before training and this can cause efficiency losses and waste of training cycles.
While it is a difficult research problem to find all the noon-productive examples, we can at least find the most obviously wrong ones.
This tool visualizes them and lets the user decide before training.

Fixes #52

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.