### PR TITLE
📝 update libero state & action notation

### DIFF
--- a/libero2lerobot/libero_utils/config.py
+++ b/libero2lerobot/libero_utils/config.py
@@ -12,12 +12,12 @@ LIBERO_FEATURES = {
     "observation.state": {
         "dtype": "float32",
         "shape": (8,),
-        "names": {"motors": ["x", "y", "z", "roll", "pitch", "yaw", "gripper", "gripper"]},
+        "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3", "gripper", "gripper"]},
     },
     "observation.states.ee_state": {
         "dtype": "float32",
         "shape": (6,),
-        "names": {"motors": ["x", "y", "z", "roll", "pitch", "yaw"]},
+        "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3"]},
     },
     "observation.states.joint_state": {
         "dtype": "float32",
@@ -32,6 +32,6 @@ LIBERO_FEATURES = {
     "action": {
         "dtype": "float32",
         "shape": (7,),
-        "names": {"motors": ["x", "y", "z", "roll", "pitch", "yaw", "gripper"]},
+        "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3", "gripper"]},
     },
 }

--- a/openx2lerobot/openx_rlds.py
+++ b/openx2lerobot/openx_rlds.py
@@ -89,7 +89,16 @@ def generate_features_from_raw(builder: tfds.core.DatasetBuilder, use_videos: bo
         if state_encoding == StateEncoding.POS_EULER:
             state_names = ["x", "y", "z", "roll", "pitch", "yaw", "pad", "gripper"]
             if "libero" in dataset_name:
-                state_names = ["x", "y", "z", "roll", "pitch", "yaw", "gripper", "gripper"]  # 2D gripper state
+                state_names = [
+                    "x",
+                    "y",
+                    "z",
+                    "axis_angle1",
+                    "axis_angle2",
+                    "axis_angle3",
+                    "gripper",
+                    "gripper",
+                ]  # 2D gripper state
         elif state_encoding == StateEncoding.POS_QUAT:
             state_names = ["x", "y", "z", "rx", "ry", "rz", "rw", "gripper"]
         elif state_encoding == StateEncoding.JOINT:
@@ -104,6 +113,8 @@ def generate_features_from_raw(builder: tfds.core.DatasetBuilder, use_videos: bo
         action_encoding = OXE_DATASET_CONFIGS[dataset_name]["action_encoding"]
         if action_encoding == ActionEncoding.EEF_POS:
             action_names = ["x", "y", "z", "roll", "pitch", "yaw", "gripper"]
+            if "libero" in dataset_name:
+                action_names = ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3", "gripper"]
         elif action_encoding == ActionEncoding.JOINT_POS:
             action_names = [f"motor_{i}" for i in range(7)] + ["gripper"]
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the incorrect state and action annotations in LIBERO, changing the orientation representation from RPY to axis–angle for consistency and correctness.

FYI:
- https://github.com/Lifelong-Robot-Learning/LIBERO/blob/8f1084e3132a39270c3a13ebe37270a43ece2a01/scripts/create_dataset.py#L203-L210
- https://github.com/Lifelong-Robot-Learning/LIBERO/issues/40#issuecomment-2425035215

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.