### PR TITLE
docs: add LeDog to Awesome LeRobot Hardware list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A curated collection of utilities for [LeRobot Projects](https://github.com/hugg
 - [LeRobot-Kinematics](https://github.com/box2ai-robotics/lerobot-kinematics): Simple and Accurate Forward and Inverse Kinematics Examples for the Lerobot SO100 ARM [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/box2ai-robotics/lerobot-kinematics">](https://github.com/box2ai-robotics/lerobot-kinematics)
 - [lerobotdepot](https://github.com/maximilienroberti/lerobotdepot): a reoi for hardware, components, and 3D-printable projects compatible with the LeRobot library [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/maximilienroberti/lerobotdepot">](https://github.com/maximilienroberti/lerobotdepot)
 - [PingTi-Arm](https://github.com/nomorewzx/PingTi-Arm): A human-scale robotic arm compatible with Lerobot, based on SO100 [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/nomorewzx/PingTi-Arm">](https://github.com/nomorewzx/PingTi-Arm)
-- [LeDog](https://github.com/wuxiaoqiang12/LeDog): A quadruped robot design compatible with LeRobot and ROS 2 (Official: [ledog_ros2](https://gitcode.com/openeuler/ledog_ros2)) [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/wuxiaoqiang12/LeDog">](https://github.com/wuxiaoqiang12/LeDog)
+- [LeDog](https://github.com/wuxiaoqiang12/LeDog): A mobile manipulator with a Weilan AlphaDog and a LeRobot-compatible SO-101 arm, with support for ROS 1/2 (Official: [ledog_ros2](https://gitcode.com/openeuler/ledog_ros2)) [<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/wuxiaoqiang12/LeDog">](https://github.com/wuxiaoqiang12/LeDog)
 
 ### Tutorial / Utils
 


### PR DESCRIPTION
Hi! I would like to add my project **LeDog** to the `Awesome LeRobot` -> `Hardware` section.

### 🤖 Project: LeDog
LeDog is a mobile manipulator design that integrates a **Weilan AlphaDog** (Quadruped) with a **SO-101 Arm**.
![side_view (1)](https://github.com/user-attachments/assets/beb8d0f9-1036-4aed-8f0c-1229522a19ff)

**Key Features:**
- **OS**: Runs on **OpenEuler Embedded 24.03** or **Ubuntu 22.04** (Orange Pi AI Pro).
- **Architecture**: Solves the coexistence of ROS 1 (Dog chassis) and ROS 2 (Arm) on an embedded system using  `ros1_bridge`.
- **Control**: Enables unified control (Joystick/MoveIt 2) for both the chassis and the arm, making it suitable for data collection.

**Links:**
- GitHub: https://github.com/wuxiaoqiang12/LeDog
- Official (OpenEuler): https://gitcode.com/openeuler/ledog_ros2

I believe this provides a valuable reference for users looking to deploy LeRobot-compatible arms on mobile platforms with complex OS environments.