### PR TITLE
🐛 sync robomind2lerobot init with latest lerobot

### DIFF
--- a/robomind2lerobot/robomind_h5.py
+++ b/robomind2lerobot/robomind_h5.py
@@ -100,7 +100,15 @@ class RoboMINDDataset(LeRobotDataset):
         obj.image_transforms = None
         obj.delta_timestamps = None
         obj.delta_indices = None
+        obj._absolute_to_relative_idx = None
         obj.video_backend = video_backend if video_backend is not None else get_safe_default_codec()
+        obj.writer = None
+        obj.latest_episode = None
+        obj._current_file_start_frame = None
+        # Initialize tracking for incremental recording
+        obj._lazy_loading = False
+        obj._recorded_frames = 0
+        obj._writer_closed_for_reading = False
         return obj
 
     def save_episode(self, split, action_config: dict, episode_data: dict | None = None) -> None:


### PR DESCRIPTION
# What does this PR do?

This PR fixes bug in `robomind2lerobot` initialization, syncing with latest lerobot commit.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `RoboMINDDataset.create` initialization with latest LeRobot to prevent missing-attribute errors.
> 
> - Initialize new state fields: `_absolute_to_relative_idx`, `writer`, `latest_episode`, `_current_file_start_frame`, `_lazy_loading`, `_recorded_frames`, `_writer_closed_for_reading`
> - No behavioral changes elsewhere; only constructor state setup adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f82e2b6098fbc6875afbd01ed8975a506622f23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->