### PR TITLE
⬆️  sync with latest lerobot

### DIFF
--- a/robomind2lerobot/robomind_h5.py
+++ b/robomind2lerobot/robomind_h5.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import ray
 from lerobot.datasets.compute_stats import aggregate_stats
-from lerobot.datasets.lerobot_dataset import LeRobotDataset, LeRobotDatasetMetadata
+from lerobot.datasets.lerobot_dataset import VALID_VIDEO_CODECS, LeRobotDataset, LeRobotDatasetMetadata
 from lerobot.datasets.utils import flatten_dict, validate_episode_buffer, write_info, write_stats
 from lerobot.datasets.video_utils import get_safe_default_codec
 from ray.runtime_env import RuntimeEnv
@@ -70,8 +70,11 @@ class RoboMINDDataset(LeRobotDataset):
         image_writer_threads: int = 0,
         video_backend: str | None = None,
         batch_encoding_size: int = 1,
+        vcodec: str = "libsvtav1",
     ) -> "LeRobotDataset":
         """Create a LeRobot Dataset from scratch in order to record data."""
+        if vcodec not in VALID_VIDEO_CODECS:
+            raise ValueError(f"Invalid vcodec '{vcodec}'. Must be one of: {sorted(VALID_VIDEO_CODECS)}")
         obj = cls.__new__(cls)
         obj.meta = RoboMINDDatasetMetadata.create(
             repo_id=repo_id,
@@ -88,6 +91,7 @@ class RoboMINDDataset(LeRobotDataset):
         obj.image_writer = None
         obj.batch_encoding_size = batch_encoding_size
         obj.episodes_since_last_encoding = 0
+        obj.vcodec = vcodec
 
         if image_writer_processes or image_writer_threads:
             obj.start_image_writer(image_writer_processes, image_writer_threads)


### PR DESCRIPTION
# What does this PR do?

This PR sync with latest lerobot commit(ec04b7c)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects dataset initialization and codec selection/validation; main risk is runtime failures if environments lack support for the new default codec.
> 
> **Overview**
> Syncs `robomind_h5.py` dataset creation with recent `lerobot` updates by introducing an explicit `vcodec` parameter (default `libsvtav1`) and persisting it on the dataset instance.
> 
> Adds validation against `lerobot`’s `VALID_VIDEO_CODECS`, failing fast with a clear error when an unsupported codec is provided, and updates imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2da35523860dde21d15844e7936923a47549f66c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->