### PR TITLE
💥 Add generic converter pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ A curated collection of utilities for [LeRobot Projects](https://github.com/hugg
 
 ## 📣 What's New <a><img width="35" height="20" src="https://user-images.githubusercontent.com/12782558/212848161-5e783dd6-11e8-4fe0-bbba-39ffb77730be.png"></a>
 
+- **\[2026.06.12\]** We have provided an efficient and concise Generic Converter for building new dataset-to-LeRobot converters with minimal adapter code! 🔥🔥🔥
 - **\[2026.03.20\]** We have supported Data Conversion from RoboCasa to LeRobot! 🔥🔥🔥
 - **\[2025.10.04\]** We have collected and updated all Dataset Version Conversion Scripts for LeRobot! 🔥🔥🔥
 - **\[2025.09.28\]** We have upgraded LeRobotDataset from v2.1 to v3.0! 🔥🔥🔥
 - **\[2025.06.27\]** We have supported Data Conversion from LIBERO to LeRobot! 🔥🔥🔥
-- **\[2025.05.16\]** We have supported Data Conversion from LeRobot to RLDS! 🔥🔥🔥
 <details>
 <summary>More News</summary>
 
+- **\[2025.05.16\]** We have supported Data Conversion from LeRobot to RLDS! 🔥🔥🔥
 - **\[2025.05.12\]** We have supported Data Conversion from RoboMIND to LeRobot! 🔥🔥🔥
 - **\[2025.04.15\]** We add Dataset Merging Tool for merging multi-source lerobot datasets! 🔥🔥🔥
 - **\[2025.04.14\]** We have supported Data Conversion from AgiBotWorld to LeRobot! 🔥🔥🔥
@@ -47,6 +48,7 @@ A curated collection of utilities for [LeRobot Projects](https://github.com/hugg
 
 - ​**​Data Conversion​**​:
 
+  - [x] [Generic Converter](./generic_converter/README.md)
   - [x] [Open X-Embodiment to LeRobot](./openx2lerobot/README.md)
   - [x] [AgiBot-World to LeRobot](./agibot2lerobot/README.md)
   - [x] [RoboMIND to LeRobot](./robomind2lerobot/README.md)

--- a/generic_converter/README.md
+++ b/generic_converter/README.md
@@ -1,0 +1,46 @@
+# Generic Converter
+
+Shared building blocks for source-dataset-to-LeRobot converters.
+
+Files:
+
+- `adapter.py`: `BaseAdapter`, the class dataset converters inherit from.
+- `pipeline.py`: the full conversion flow: write temporary LeRobot datasets, aggregate, clean up, and optionally push.
+- `utils.py`: shared data structures and small framework helpers.
+
+The intended adapter flow is:
+
+1. Subclass `BaseAdapter`.
+2. Set dataset-level fields: `dataset_type`, `fps`, `robot_type`, `features`, and optional `tags`.
+3. Implement `load_tasks(...)` to discover or load `ConversionTask` objects. Use `metadata`
+   for dataset-specific values such as language task strings.
+4. Implement `load_subset(input_path, metadata)` to yield episodes of frame dictionaries.
+5. Call `run_converter(..., adapter=adapter)`.
+
+Minimal shape:
+
+```python
+class MyAdapter(BaseAdapter):
+    dataset_type = "my_dataset"
+    fps = 20
+    robot_type = "robot"
+    features = MY_FEATURES
+
+    def load_tasks(self, output_path, *, src_paths=None, tasks_file=None):
+        ...
+
+    def load_subset(self, input_path, metadata):
+        ...
+```
+
+Task manifests are dataset-specific. If a converter wants JSON/CSV/YAML task
+files, implement that parser in its adapter rather than in this generic
+package.
+
+This generic converter is intentionally scoped to source datasets that can be
+converted into normal LeRobot episodes. Datasets that require custom
+LeRobotDataset writers or custom episode metadata can still reuse pieces here,
+but should not force-fit into this pipeline.
+
+Temporary task datasets are removed by default after aggregation. Pass
+`cleanup_temp=False` to `run_converter` when debugging temporary outputs.

--- a/generic_converter/README.md
+++ b/generic_converter/README.md
@@ -26,8 +26,8 @@ Dataset-specific converters own the adapter logic:
 
 ## Adapter Contract
 
-A dataset converter should subclass `BaseAdapter` and provide dataset-level
-metadata as class attributes.
+A dataset converter should subclass `BaseAdapter`, pass `output_path` to the
+base constructor, and provide dataset-level metadata as class attributes.
 
 Required attributes:
 
@@ -35,7 +35,6 @@ Required attributes:
 - `fps`
 - `robot_type`
 - `features`
-- `output_path`
 
 Optional attributes:
 
@@ -46,8 +45,9 @@ Required methods:
 - `load_tasks(self) -> list[ConversionTask]`
 - `load_subset(self, task: ConversionTask) -> Iterable[Sequence[dict]]`
 
-`run_converter` calls `adapter.load_tasks()` without arguments. Store paths,
-task manifests, or other adapter options on the adapter instance in `__init__`.
+`run_converter` reads `adapter.output_path` and calls `adapter.load_tasks()`
+without arguments. Store paths, task manifests, or other adapter options on the
+adapter instance in `__init__`.
 
 `load_subset` receives the full `ConversionTask`, not just an input path. Use
 `task.input_path` for raw data and `task.metadata` for dataset-specific values
@@ -79,6 +79,9 @@ class MyAdapter(BaseAdapter):
     robot_type = "my_robot"
     features = MY_FEATURES
     tags = ["my_dataset"]
+
+    def __init__(self, output_path):
+        super().__init__(output_path)
 
     def load_tasks(self) -> list[ConversionTask]:
         ...

--- a/generic_converter/README.md
+++ b/generic_converter/README.md
@@ -1,46 +1,148 @@
 # Generic Converter
 
-Shared building blocks for source-dataset-to-LeRobot converters.
+Shared conversion flow for turning task-based source datasets into LeRobot
+datasets.
 
-Files:
+The generic package owns the execution mechanics:
 
-- `adapter.py`: `BaseAdapter`, the class dataset converters inherit from.
-- `pipeline.py`: the full conversion flow: write temporary LeRobot datasets, aggregate, clean up, and optionally push.
-- `utils.py`: shared data structures and small framework helpers.
+- create one temporary `LeRobotDataset` per `ConversionTask`
+- run tasks with a local or Ray Datatrove executor
+- aggregate temporary datasets into the adapter output directory
+- remove temporary task outputs by default
+- optionally push the aggregated dataset to the Hub
 
-The intended adapter flow is:
+Dataset-specific converters own the adapter logic:
 
-1. Subclass `BaseAdapter`.
-2. Set dataset-level fields: `dataset_type`, `fps`, `robot_type`, `features`, and optional `tags`.
-3. Implement `load_tasks(...)` to discover or load `ConversionTask` objects. Use `metadata`
-   for dataset-specific values such as language task strings.
-4. Implement `load_subset(input_path, metadata)` to yield episodes of frame dictionaries.
-5. Call `run_converter(..., adapter=adapter)`.
+- where raw inputs come from
+- how tasks are discovered or loaded
+- how one raw input is converted into LeRobot episodes
+- how task metadata, such as language instructions, is represented
 
-Minimal shape:
+## Files
+
+- `adapter.py`: `BaseAdapter`, the class dataset adapters inherit from.
+- `pipeline.py`: the reusable conversion, executor, aggregation, cleanup, and push flow.
+- `utils.py`: shared types and small helpers.
+
+## Adapter Contract
+
+A dataset converter should subclass `BaseAdapter` and provide dataset-level
+metadata as class attributes.
+
+Required attributes:
+
+- `dataset_type`
+- `fps`
+- `robot_type`
+- `features`
+- `output_path`
+
+Optional attributes:
+
+- `tags`
+
+Required methods:
+
+- `load_tasks(self) -> list[ConversionTask]`
+- `load_subset(self, task: ConversionTask) -> Iterable[Sequence[dict]]`
+
+`run_converter` calls `adapter.load_tasks()` without arguments. Store paths,
+task manifests, or other adapter options on the adapter instance in `__init__`.
+
+`load_subset` receives the full `ConversionTask`, not just an input path. Use
+`task.input_path` for raw data and `task.metadata` for dataset-specific values
+such as language instructions. Each yielded episode must be a sequence of frame
+dictionaries accepted by `LeRobotDataset.add_frame`; each frame should include
+the LeRobot `task` field when language tasks are needed.
+
+## ConversionTask
+
+`ConversionTask` describes one independently convertible raw input:
+
+- `input_path`: source file or directory
+- `output_path`: temporary LeRobot dataset directory for this task
+- `local_repo_id`: repo id used while writing the temporary dataset
+- `metadata`: adapter-owned metadata
+
+Keep dataset-specific values in `metadata`; the generic pipeline does not know
+about task-file schemas or instruction formats.
+
+## Minimal Adapter
 
 ```python
+from pathlib import Path
+
+from generic_converter import BaseAdapter, ConversionTask, run_converter
+
+
 class MyAdapter(BaseAdapter):
     dataset_type = "my_dataset"
     fps = 20
-    robot_type = "robot"
+    robot_type = "my_robot"
     features = MY_FEATURES
+    tags = ["my_dataset"]
 
-    def load_tasks(self, output_path, *, src_paths=None, tasks_file=None):
-        ...
+    def __init__(self, src_paths: list[Path], output_path: Path):
+        self.src_paths = [path.expanduser().resolve() for path in src_paths]
+        self.output_path = output_path.expanduser().resolve()
 
-    def load_subset(self, input_path, metadata):
-        ...
+    def load_tasks(self) -> list[ConversionTask]:
+        tasks = []
+        temp_root = self.output_path.with_name(f"{self.output_path.name}_temp")
+        for src_path in self.src_paths:
+            for raw_file in src_path.glob("*.hdf5"):
+                tasks.append(
+                    ConversionTask(
+                        input_path=raw_file.resolve(),
+                        output_path=(temp_root / src_path.name / raw_file.stem).resolve(),
+                        local_repo_id=f"{src_path.name}/{raw_file.name}",
+                        metadata={"task": raw_file.stem.replace("_", " ")},
+                    )
+                )
+        return tasks
+
+    def load_subset(self, task: ConversionTask):
+        for raw_episode in load_raw_episodes(task.input_path):
+            yield [
+                {
+                    **frame,
+                    "task": task.metadata["task"],
+                }
+                for frame in raw_episode
+            ]
+
+
+adapter = MyAdapter(src_paths=[Path("raw")], output_path=Path("output/my_dataset"))
+run_converter(
+    adapter=adapter,
+    executor="local",
+    cpus_per_task=4,
+    tasks_per_job=1,
+    workers=4,
+)
 ```
 
-Task manifests are dataset-specific. If a converter wants JSON/CSV/YAML task
-files, implement that parser in its adapter rather than in this generic
-package.
+## Execution Notes
 
-This generic converter is intentionally scoped to source datasets that can be
-converted into normal LeRobot episodes. Datasets that require custom
-LeRobotDataset writers or custom episode metadata can still reuse pieces here,
-but should not force-fit into this pipeline.
+`executor="local"` uses Datatrove's local executor.
 
-Temporary task datasets are removed by default after aggregation. Pass
-`cleanup_temp=False` to `run_converter` when debugging temporary outputs.
+`executor="ray"` uses Datatrove's Ray executor. The pipeline builds a Ray
+runtime environment with `PYTHONPATH` entries for the repository root, current
+working directory, the current Python path, and the existing environment
+`PYTHONPATH` so Ray workers can import local packages such as
+`generic_converter`.
+
+`debug=True` forces local execution, sets `workers=1`, disables Hub upload, and
+only runs the first two tasks.
+
+`cleanup_temp=True` removes each task's temporary `output_path` after
+aggregation.
+
+## What Stays In Adapters
+
+Task manifests are dataset-specific. If a converter wants JSON, CSV, YAML, or
+another task description format, parse it inside that converter's adapter.
+
+Adapters should also own dataset-specific naming, metadata inference, and raw
+file parsing. The generic pipeline should stay limited to execution and
+LeRobot dataset assembly.

--- a/generic_converter/README.md
+++ b/generic_converter/README.md
@@ -67,11 +67,9 @@ the LeRobot `task` field when language tasks are needed.
 Keep dataset-specific values in `metadata`; the generic pipeline does not know
 about task-file schemas or instruction formats.
 
-## Minimal Adapter
+## Usage Sketch
 
 ```python
-from pathlib import Path
-
 from generic_converter import BaseAdapter, ConversionTask, run_converter
 
 
@@ -82,67 +80,18 @@ class MyAdapter(BaseAdapter):
     features = MY_FEATURES
     tags = ["my_dataset"]
 
-    def __init__(self, src_paths: list[Path], output_path: Path):
-        self.src_paths = [path.expanduser().resolve() for path in src_paths]
-        self.output_path = output_path.expanduser().resolve()
-
     def load_tasks(self) -> list[ConversionTask]:
-        tasks = []
-        temp_root = self.output_path.with_name(f"{self.output_path.name}_temp")
-        for src_path in self.src_paths:
-            for raw_file in src_path.glob("*.hdf5"):
-                tasks.append(
-                    ConversionTask(
-                        input_path=raw_file.resolve(),
-                        output_path=(temp_root / src_path.name / raw_file.stem).resolve(),
-                        local_repo_id=f"{src_path.name}/{raw_file.name}",
-                        metadata={"task": raw_file.stem.replace("_", " ")},
-                    )
-                )
-        return tasks
+        ...
 
     def load_subset(self, task: ConversionTask):
-        for raw_episode in load_raw_episodes(task.input_path):
-            yield [
-                {
-                    **frame,
-                    "task": task.metadata["task"],
-                }
-                for frame in raw_episode
-            ]
+        ...
 
 
-adapter = MyAdapter(src_paths=[Path("raw")], output_path=Path("output/my_dataset"))
 run_converter(
     adapter=adapter,
     executor="local",
-    cpus_per_task=4,
+    cpus_per_task=1,
     tasks_per_job=1,
-    workers=4,
+    workers=-1,
 )
 ```
-
-## Execution Notes
-
-`executor="local"` uses Datatrove's local executor.
-
-`executor="ray"` uses Datatrove's Ray executor. The pipeline builds a Ray
-runtime environment with `PYTHONPATH` entries for the repository root, current
-working directory, the current Python path, and the existing environment
-`PYTHONPATH` so Ray workers can import local packages such as
-`generic_converter`.
-
-`debug=True` forces local execution, sets `workers=1`, disables Hub upload, and
-only runs the first two tasks.
-
-`cleanup_temp=True` removes each task's temporary `output_path` after
-aggregation.
-
-## What Stays In Adapters
-
-Task manifests are dataset-specific. If a converter wants JSON, CSV, YAML, or
-another task description format, parse it inside that converter's adapter.
-
-Adapters should also own dataset-specific naming, metadata inference, and raw
-file parsing. The generic pipeline should stay limited to execution and
-LeRobot dataset assembly.

--- a/generic_converter/README.md
+++ b/generic_converter/README.md
@@ -49,6 +49,8 @@ Required methods:
 without arguments. Store paths, task manifests, or other adapter options on the
 adapter instance in `__init__`.
 
+Use `adapter.temp_output_path` when building task-level temporary output paths.
+
 `load_subset` receives the full `ConversionTask`, not just an input path. Use
 `task.input_path` for raw data and `task.metadata` for dataset-specific values
 such as language instructions. Each yielded episode must be a sequence of frame

--- a/generic_converter/__init__.py
+++ b/generic_converter/__init__.py
@@ -1,0 +1,11 @@
+from .adapter import BaseAdapter
+from .pipeline import run_converter
+from .utils import ConversionTask, FeatureSpec, TaskMetadata
+
+__all__ = [
+    "BaseAdapter",
+    "ConversionTask",
+    "FeatureSpec",
+    "TaskMetadata",
+    "run_converter",
+]

--- a/generic_converter/adapter.py
+++ b/generic_converter/adapter.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
-from pathlib import Path
 
 from .utils import ConversionTask, FeatureSpec
 
@@ -15,13 +14,7 @@ class BaseAdapter(ABC):
     tags: Sequence[str] = ()
 
     @abstractmethod
-    def load_tasks(
-        self,
-        output_path: Path,
-        *,
-        src_paths: Sequence[Path] | None = None,
-        tasks_file: Path | None = None,
-    ) -> list[ConversionTask]:
+    def load_tasks(self) -> list[ConversionTask]:
         """Build conversion tasks from dataset-specific inputs."""
 
     @abstractmethod

--- a/generic_converter/adapter.py
+++ b/generic_converter/adapter.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from .utils import ConversionTask, FeatureSpec
+
+
+class BaseAdapter(ABC):
+    """Dataset-specific hooks used by the generic conversion pipeline."""
+
+    dataset_type: str
+    fps: int
+    robot_type: str
+    features: FeatureSpec
+    tags: Sequence[str] = ()
+
+    @abstractmethod
+    def load_tasks(
+        self,
+        output_path: Path,
+        *,
+        src_paths: Sequence[Path] | None = None,
+        tasks_file: Path | None = None,
+    ) -> list[ConversionTask]:
+        """Build conversion tasks from dataset-specific inputs."""
+
+    @abstractmethod
+    def load_subset(
+        self, task: ConversionTask
+    ) -> Iterable[Sequence[dict]]:
+        """Yield LeRobot episodes for one raw input path."""

--- a/generic_converter/adapter.py
+++ b/generic_converter/adapter.py
@@ -17,6 +17,10 @@ class BaseAdapter(ABC):
     def __init__(self, output_path: Path):
         self.output_path = output_path.expanduser().resolve()
 
+    @property
+    def temp_output_path(self) -> Path:
+        return self.output_path.with_name(f"{self.output_path.name}_temp")
+
     @abstractmethod
     def load_tasks(self) -> list[ConversionTask]:
         """Build conversion tasks from dataset-specific inputs."""

--- a/generic_converter/adapter.py
+++ b/generic_converter/adapter.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
+from pathlib import Path
 
 from .utils import ConversionTask, FeatureSpec
 
@@ -12,6 +13,9 @@ class BaseAdapter(ABC):
     robot_type: str
     features: FeatureSpec
     tags: Sequence[str] = ()
+
+    def __init__(self, output_path: Path):
+        self.output_path = output_path.expanduser().resolve()
 
     @abstractmethod
     def load_tasks(self) -> list[ConversionTask]:

--- a/generic_converter/pipeline.py
+++ b/generic_converter/pipeline.py
@@ -1,0 +1,221 @@
+import os
+import shutil
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from datatrove.pipeline.base import PipelineStep
+from lerobot.datasets import LeRobotDataset
+from lerobot.datasets.aggregate import aggregate_datasets
+
+from .adapter import BaseAdapter
+from .utils import (
+    ConversionTask,
+    setup_logger,
+    unique_strings,
+)
+
+
+class SaveLeRobotDataset(PipelineStep):
+    name = "Save Temp LeRobotDataset"
+
+    def __init__(self, tasks: list[ConversionTask], adapter: BaseAdapter):
+        super().__init__()
+        self.tasks = tasks
+        self.adapter = adapter
+        self.type = f"{adapter.dataset_type}2lerobot"
+
+    def run(self, data=None, rank: int = 0, world_size: int = 1):
+        logger = setup_logger()
+        task = self.tasks[rank]
+
+        if task.output_path.exists():
+            shutil.rmtree(task.output_path)
+
+        dataset = LeRobotDataset.create(
+            repo_id=task.local_repo_id,
+            root=task.output_path,
+            fps=self.adapter.fps,
+            robot_type=self.adapter.robot_type,
+            features=self.adapter.features,
+        )
+
+        logger.info(
+            f"start processing for {task.input_path}, saving to {task.output_path}"
+        )
+        raw_dataset = self.adapter.load_subset(task)
+        for episode_index, episode_data in enumerate(raw_dataset):
+            with self.track_time("saving episode"):
+                for frame in episode_data:
+                    dataset.add_frame(frame)
+                dataset.save_episode()
+                logger.info(
+                    f"process done for {dataset.repo_id}, episode {episode_index}, len {len(episode_data)}"
+                )
+        dataset.finalize()
+
+
+def run_converter(
+    adapter: BaseAdapter,
+    executor: str,
+    cpus_per_task: int,
+    tasks_per_job: int,
+    workers: int,
+    resume_dir: str | None = None,
+    debug: bool = False,
+    local_repo_id: str | None = None,
+    hub_repo_id: str | None = None,
+    push_to_hub: bool = False,
+    cleanup_temp: bool = True,
+    extra_tags: Sequence[str] | None = None,
+) -> Path:
+    tasks = adapter.load_tasks()
+    output_path = adapter.output_path
+
+    if not tasks:
+        raise ValueError(
+            "No conversion tasks found. Provide a non-empty tasks file or matching source files."
+        )
+    if cpus_per_task < 1:
+        raise ValueError("--cpus-per-task must be >= 1")
+
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if debug:
+        executor = "local"
+        workers = 1
+        tasks = tasks[:2]
+        push_to_hub = False
+
+    match executor:
+        case "local":
+            from datatrove.executor import LocalPipelineExecutor
+
+            resolved_workers = (
+                max(1, (os.cpu_count() or 1) // cpus_per_task)
+                if workers == -1
+                else workers
+            )
+            executor_cls, executor_config = LocalPipelineExecutor, {
+                "tasks": len(tasks),
+                "workers": resolved_workers,
+            }
+        case "ray":
+            import ray
+            from datatrove.executor import RayPipelineExecutor
+            from ray.runtime_env import RuntimeEnv
+
+            runtime_env = RuntimeEnv(env_vars=_build_ray_env_vars())
+            ray.init(runtime_env=runtime_env)
+            executor_cls, executor_config = RayPipelineExecutor, {
+                "tasks": len(tasks),
+                "workers": workers,
+                "cpus_per_task": cpus_per_task,
+                "tasks_per_job": tasks_per_job,
+            }
+        case _:
+            raise ValueError(f"Executor {executor} not supported")
+
+    executor_cls(
+        pipeline=[SaveLeRobotDataset(tasks, adapter)],
+        **executor_config,
+        logging_dir=str(resume_dir) if resume_dir else None,
+    ).run()
+    aggregate_tasks(tasks, output_path, aggr_repo_id=local_repo_id)
+
+    if cleanup_temp:
+        logger = setup_logger()
+        logger.info("Delete temp data_dir")
+        for temp_dir in [task.output_path for task in tasks]:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    if push_to_hub:
+        if hub_repo_id is None:
+            raise ValueError("--repo-id is required when --push-to-hub is set")
+
+        tags = unique_strings(
+            [
+                "LeRobot",
+                adapter.dataset_type,
+                adapter.robot_type,
+                *adapter.tags,
+                *(extra_tags or []),
+            ]
+        )
+        LeRobotDataset(
+            repo_id=hub_repo_id,
+            root=output_path,
+        ).push_to_hub(
+            tags=tags,
+            private=False,
+            push_videos=True,
+            license="apache-2.0",
+            upload_large_folder=False,
+        )
+
+    return output_path
+
+
+def _build_ray_env_vars() -> dict[str, str]:
+    env_vars = {
+        "HDF5_USE_FILE_LOCKING": "FALSE",
+        "HF_DATASETS_DISABLE_PROGRESS_BARS": "TRUE",
+        "SVT_LOG": "1",
+    }
+    pythonpath = _build_ray_pythonpath()
+    if pythonpath:
+        env_vars["PYTHONPATH"] = pythonpath
+    return env_vars
+
+
+def _build_ray_pythonpath() -> str:
+    repo_root = Path(__file__).resolve().parents[1]
+    paths: list[str] = []
+
+    def add_path(path_value: str | Path):
+        path = Path(path_value).expanduser()
+        try:
+            path = path.resolve()
+        except OSError:
+            return
+        if not path.exists():
+            return
+        path_str = str(path)
+        if path_str not in paths:
+            paths.append(path_str)
+
+    add_path(repo_root)
+    add_path(Path.cwd())
+    for path in sys.path:
+        if path:
+            add_path(path)
+    for path in os.environ.get("PYTHONPATH", "").split(os.pathsep):
+        if path:
+            add_path(path)
+
+    return os.pathsep.join(paths)
+
+
+def aggregate_tasks(
+    tasks: list[ConversionTask],
+    output_dir: Path,
+    aggr_repo_id: str | None = None,
+):
+    logger = setup_logger()
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+
+    roots = [task.output_path for task in tasks]
+    resolved_aggr_repo_id = aggr_repo_id or output_dir.name
+
+    logger.info(
+        f"aggregate {len(tasks)} temporary datasets into {output_dir} as {resolved_aggr_repo_id}"
+    )
+    aggregate_datasets(
+        repo_ids=[None] * len(tasks),
+        roots=roots,
+        aggr_repo_id=resolved_aggr_repo_id,
+        aggr_root=output_dir,
+    )
+    logger.info(f"aggregation complete: {output_dir}")

--- a/generic_converter/utils.py
+++ b/generic_converter/utils.py
@@ -1,0 +1,39 @@
+import shutil
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+TaskMetadata = Mapping[str, Any]
+FeatureSpec = Mapping[str, dict]
+
+
+@dataclass(frozen=True)
+class ConversionTask:
+    """One independently convertible raw input file and adapter metadata."""
+
+    input_path: Path
+    output_path: Path
+    local_repo_id: str | None = None
+    metadata: TaskMetadata = field(default_factory=dict)
+
+
+def setup_logger():
+    import sys
+
+    from datatrove.utils.logging import logger
+
+    logger.remove()
+    logger.add(sys.stdout, level="INFO", colorize=True)
+    return logger
+
+
+def unique_strings(values: Sequence[str]) -> list[str]:
+    result = []
+    seen = set()
+    for value in values:
+        if value in seen:
+            continue
+        result.append(value)
+        seen.add(value)
+    return result

--- a/libero2lerobot/libero_h5.py
+++ b/libero2lerobot/libero_h5.py
@@ -1,127 +1,142 @@
 import argparse
+import os
 import re
-import sys
-from collections.abc import Iterable, Sequence
+import shutil
 from pathlib import Path
 
-import numpy as np
-from h5py import File
+import pandas as pd
+import ray
+from datatrove.executor import LocalPipelineExecutor, RayPipelineExecutor
+from datatrove.pipeline.base import PipelineStep
+from lerobot.datasets import LeRobotDataset, LeRobotDatasetMetadata
+from lerobot.datasets.aggregate import (
+    aggregate_data,
+    aggregate_metadata,
+    aggregate_stats,
+    aggregate_videos,
+    validate_all_metadata,
+)
+from lerobot.datasets.io_utils import write_info, write_stats, write_tasks
+from lerobot.datasets.utils import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_DATA_FILE_SIZE_IN_MB,
+    DEFAULT_VIDEO_FILE_SIZE_IN_MB,
+)
+from libero_utils.config import LIBERO_FEATURES
+from libero_utils.libero_utils import load_local_episodes
+from ray.runtime_env import RuntimeEnv
+from tqdm import tqdm
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
 
-from generic_converter import BaseAdapter, ConversionTask, run_converter  # noqa: E402
+def setup_logger():
+    import sys
+
+    from datatrove.utils.logging import logger
+
+    logger.remove()
+    logger.add(sys.stdout, level="INFO", colorize=True)
+    return logger
 
 
-class LiberoAdapter(BaseAdapter):
-    dataset_type = "libero"
-    fps = 20
-    robot_type = "franka"
-    features = {
-        "observation.images.image": {
-            "dtype": "video",
-            "shape": (256, 256, 3),
-            "names": ["height", "width", "rgb"],
-        },
-        "observation.images.wrist_image": {
-            "dtype": "video",
-            "shape": (256, 256, 3),
-            "names": ["height", "width", "rgb"],
-        },
-        "observation.state": {
-            "dtype": "float32",
-            "shape": (8,),
-            "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3", "gripper", "gripper"]},
-        },
-        "observation.states.ee_state": {
-            "dtype": "float32",
-            "shape": (6,),
-            "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3"]},
-        },
-        "observation.states.joint_state": {
-            "dtype": "float32",
-            "shape": (7,),
-            "names": {"motors": ["joint_0", "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]},
-        },
-        "observation.states.gripper_state": {
-            "dtype": "float32",
-            "shape": (2,),
-            "names": {"motors": ["gripper", "gripper"]},
-        },
-        "action": {
-            "dtype": "float32",
-            "shape": (7,),
-            "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3", "gripper"]},
-        },
-    }
-    tags = ["libero", "franka"]
+class SaveLerobotDataset(PipelineStep):
+    name = "Save Temp LerobotDataset"
+    type = "libero2lerobot"
 
-    def __init__(self, src_paths: list[Path], output_path: Path):
-        super().__init__(output_path)
-        self.src_paths = src_paths
+    def __init__(self, tasks: list[tuple[Path, Path, str]]):
+        super().__init__()
+        self.tasks = tasks
 
-    def load_tasks(self) -> list[ConversionTask]:
-        tasks = []
-        for src_path in self.src_paths:
-            for input_h5 in src_path.glob("*.hdf5"):
-                pattern1 = re.compile(r"_SCENE\d+_(.*?)_demo\.hdf5")
-                pattern2 = re.compile(r"(.*?)_demo\.hdf5")
+    def run(self, data=None, rank: int = 0, world_size: int = 1):
+        logger = setup_logger()
 
-                match = pattern1.search(input_h5.name)
-                if match is None:
-                    match = pattern2.search(input_h5.name)
-                if match is None:
-                    continue
-                else:
-                    task_instruction = match.group(1).replace("_", " ")
+        input_h5, output_path, task_instruction = self.tasks[rank]
 
-                tasks.append(
-                    ConversionTask(
-                        input_path=input_h5.resolve(),
-                        output_path=(
-                            self.temp_output_path
-                            / f"{src_path.name}"
-                            / input_h5.stem
-                        ).resolve(),
-                        local_repo_id=f"{input_h5.parent.name}/{input_h5.name}",
-                        metadata={"task": task_instruction},
-                    )
-                )
-        return tasks
+        if output_path.exists():
+            shutil.rmtree(output_path)
 
-    def load_subset(self, task: ConversionTask) -> Iterable[Sequence[dict]]:
-        input_h5 = task.input_path
-        task_instruction = task.metadata.get("task")
-        with File(input_h5, "r") as f:
-            for demo in f["data"].values():
-                demo_len = len(demo["obs/agentview_rgb"])
-                # (-1: open, 1: close) -> (0: close, 1: open)
-                action = np.array(demo["actions"])
-                action = np.concatenate(
-                    [
-                        action[:, :6],
-                        (1 - np.clip(action[:, -1], 0, 1))[:, None],
-                    ],
-                    axis=1,
-                )
-                state = np.concatenate(
-                    [
-                        np.array(demo["obs/ee_states"]),
-                        np.array(demo["obs/gripper_states"]),
-                    ],
-                    axis=1,
-                )
-                episode = {
-                    "observation.images.image": np.array(demo["obs/agentview_rgb"]),
-                    "observation.images.wrist_image": np.array(demo["obs/eye_in_hand_rgb"]),
-                    "observation.state": np.array(state, dtype=np.float32),
-                    "observation.states.ee_state": np.array(demo["obs/ee_states"], dtype=np.float32),
-                    "observation.states.joint_state": np.array(demo["obs/joint_states"], dtype=np.float32),
-                    "observation.states.gripper_state": np.array(demo["obs/gripper_states"], dtype=np.float32),
-                    "action": np.array(action, dtype=np.float32),
-                }
-                yield [{**{k: v[i] for k, v in episode.items()}, "task": task_instruction} for i in range(demo_len)]
+        dataset = LeRobotDataset.create(
+            repo_id=f"{input_h5.parent.name}/{input_h5.name}",
+            root=output_path,
+            fps=20,
+            robot_type="franka",
+            features=LIBERO_FEATURES,
+        )
+
+        logger.info(f"start processing for {input_h5}, saving to {output_path}")
+
+        raw_dataset = load_local_episodes(input_h5)
+        for episode_index, episode_data in enumerate(raw_dataset):
+            with self.track_time("saving episode"):
+                for frame_data in episode_data:
+                    frame_data["task"] = task_instruction
+                    dataset.add_frame(frame_data)
+                dataset.save_episode()
+                logger.info(f"process done for {dataset.repo_id}, episode {episode_index}, len {len(episode_data)}")
+
+
+def create_aggr_dataset(raw_dirs: list[Path], aggregated_dir: Path):
+    logger = setup_logger()
+
+    all_metadata = [LeRobotDatasetMetadata("", root=raw_dir) for raw_dir in raw_dirs]
+
+    fps, robot_type, features = validate_all_metadata(all_metadata)
+
+    if aggregated_dir.exists():
+        shutil.rmtree(aggregated_dir)
+
+    aggr_meta = LeRobotDatasetMetadata.create(
+        repo_id=f"{aggregated_dir.parent.name}/{aggregated_dir.name}",
+        root=aggregated_dir,
+        fps=fps,
+        robot_type=robot_type,
+        features=features,
+    )
+
+    video_keys = [key for key in features if features[key]["dtype"] == "video"]
+    unique_tasks = pd.concat([m.tasks for m in all_metadata]).index.unique()
+    aggr_meta.tasks = pd.DataFrame({"task_index": range(len(unique_tasks))}, index=unique_tasks)
+
+    meta_idx = {"chunk": 0, "file": 0}
+    data_idx = {"chunk": 0, "file": 0}
+    videos_idx = {key: {"chunk": 0, "file": 0, "latest_duration": 0, "episode_duration": 0} for key in video_keys}
+
+    aggr_meta.episodes = {}
+
+    for src_meta in tqdm(all_metadata, desc="Copy data and videos"):
+        videos_idx = aggregate_videos(
+            src_meta, aggr_meta, videos_idx, DEFAULT_VIDEO_FILE_SIZE_IN_MB, DEFAULT_CHUNK_SIZE
+        )
+        data_idx = aggregate_data(src_meta, aggr_meta, data_idx, DEFAULT_DATA_FILE_SIZE_IN_MB, DEFAULT_CHUNK_SIZE)
+
+        meta_idx = aggregate_metadata(src_meta, aggr_meta, meta_idx, data_idx, videos_idx)
+
+        aggr_meta.info["total_episodes"] += src_meta.total_episodes
+        aggr_meta.info["total_frames"] += src_meta.total_frames
+
+    logger.info("write tasks")
+    write_tasks(aggr_meta.tasks, aggr_meta.root)
+
+    logger.info("write info")
+    aggr_meta.info.update(
+        {
+            "total_tasks": len(aggr_meta.tasks),
+            "total_episodes": sum(m.total_episodes for m in all_metadata),
+            "total_frames": sum(m.total_frames for m in all_metadata),
+            "splits": {"train": f"0:{sum(m.total_episodes for m in all_metadata)}"},
+        }
+    )
+    write_info(aggr_meta.info, aggr_meta.root)
+
+    logger.info("write stats")
+    aggr_meta.stats = aggregate_stats([m.stats for m in all_metadata])
+    write_stats(aggr_meta.stats, aggr_meta.root)
+
+
+def delete_temp_data(temp_dirs: list[Path]):
+    logger = setup_logger()
+    logger.info("Delete temp data_dir")
+    for temp_dir in temp_dirs:
+        shutil.rmtree(temp_dir)
 
 
 def main(
@@ -131,25 +146,86 @@ def main(
     cpus_per_task: int,
     tasks_per_job: int,
     workers: int,
-    resume_dir: Path | None = None,
+    resume_dir: Path = None,
     debug: bool = False,
-    repo_id: str | None = None,
+    repo_id: str = None,
     push_to_hub: bool = False,
 ):
-    adapter = LiberoAdapter(src_paths, output_path)
+    tasks = []
+    pattern1 = re.compile(r"_SCENE\d+_(.*?)_demo\.hdf5")
+    pattern2 = re.compile(r"(.*?)_demo\.hdf5")
+    for src_path in src_paths:
+        for input_h5 in src_path.glob("*.hdf5"):
+            match = pattern1.search(input_h5.name)
+            if match is None:
+                match = pattern2.search(input_h5.name)
+                if match is None:
+                    continue
+            tasks.append(
+                (
+                    input_h5,
+                    (output_path / (src_path.name + "_temp") / input_h5.stem).resolve(),
+                    match.group(1).replace("_", " "),
+                )
+            )
+    if len(src_paths) > 1:
+        aggregate_output_path = output_path / (
+            "_".join([src_path.name for src_path in src_paths]) + "_aggregated_lerobot"
+        )
+    else:
+        aggregate_output_path = output_path / f"{src_paths[0].name}_lerobot"
+    aggregate_output_path = aggregate_output_path.resolve()
 
-    run_converter(
-        adapter=adapter,
-        executor=executor,
-        cpus_per_task=cpus_per_task,
-        tasks_per_job=tasks_per_job,
-        workers=workers,
-        resume_dir=resume_dir,
-        debug=debug,
-        local_repo_id=repo_id,
-        hub_repo_id=repo_id,
-        push_to_hub=push_to_hub,
-    )
+    if debug:
+        executor = "local"
+        workers = 1
+        tasks = tasks[:2]
+        push_to_hub = False
+
+    match executor:
+        case "local":
+            workers = os.cpu_count() // cpus_per_task if workers == -1 else workers
+            executor = LocalPipelineExecutor
+        case "ray":
+            runtime_env = RuntimeEnv(
+                env_vars={
+                    "HDF5_USE_FILE_LOCKING": "FALSE",
+                    "HF_DATASETS_DISABLE_PROGRESS_BARS": "TRUE",
+                    "SVT_LOG": "1",
+                },
+            )
+            ray.init(runtime_env=runtime_env)
+            executor = RayPipelineExecutor
+        case _:
+            raise ValueError(f"Executor {executor} not supported")
+
+    executor_config = {
+        "tasks": len(tasks),
+        "workers": workers,
+        **({"cpus_per_task": cpus_per_task, "tasks_per_job": tasks_per_job} if executor is RayPipelineExecutor else {}),
+    }
+
+    executor(pipeline=[SaveLerobotDataset(tasks)], **executor_config, logging_dir=resume_dir).run()
+    create_aggr_dataset([task[1] for task in tasks], aggregate_output_path)
+    delete_temp_data([task[1] for task in tasks])
+
+    for task in tasks:
+        shutil.rmtree(task[1].parent, ignore_errors=True)
+
+    if push_to_hub:
+        assert repo_id is not None
+        tags = ["LeRobot", "libero", "franka"]
+        tags.extend([src_path.name for src_path in src_paths])
+        LeRobotDataset(
+            repo_id=repo_id,
+            root=aggregate_output_path,
+        ).push_to_hub(
+            tags=tags,
+            private=False,
+            push_videos=True,
+            license="apache-2.0",
+            upload_large_folder=False,
+        )
 
 
 if __name__ == "__main__":

--- a/libero2lerobot/libero_h5.py
+++ b/libero2lerobot/libero_h5.py
@@ -1,142 +1,127 @@
 import argparse
-import os
 import re
-import shutil
+import sys
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-import pandas as pd
-import ray
-from datatrove.executor import LocalPipelineExecutor, RayPipelineExecutor
-from datatrove.pipeline.base import PipelineStep
-from lerobot.datasets import LeRobotDataset, LeRobotDatasetMetadata
-from lerobot.datasets.aggregate import (
-    aggregate_data,
-    aggregate_metadata,
-    aggregate_stats,
-    aggregate_videos,
-    validate_all_metadata,
-)
-from lerobot.datasets.io_utils import write_info, write_stats, write_tasks
-from lerobot.datasets.utils import (
-    DEFAULT_CHUNK_SIZE,
-    DEFAULT_DATA_FILE_SIZE_IN_MB,
-    DEFAULT_VIDEO_FILE_SIZE_IN_MB,
-)
-from libero_utils.config import LIBERO_FEATURES
-from libero_utils.libero_utils import load_local_episodes
-from ray.runtime_env import RuntimeEnv
-from tqdm import tqdm
+import numpy as np
+from h5py import File
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from generic_converter import BaseAdapter, ConversionTask, run_converter  # noqa: E402
 
 
-def setup_logger():
-    import sys
+class LiberoAdapter(BaseAdapter):
+    dataset_type = "libero"
+    fps = 20
+    robot_type = "franka"
+    features = {
+        "observation.images.image": {
+            "dtype": "video",
+            "shape": (256, 256, 3),
+            "names": ["height", "width", "rgb"],
+        },
+        "observation.images.wrist_image": {
+            "dtype": "video",
+            "shape": (256, 256, 3),
+            "names": ["height", "width", "rgb"],
+        },
+        "observation.state": {
+            "dtype": "float32",
+            "shape": (8,),
+            "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3", "gripper", "gripper"]},
+        },
+        "observation.states.ee_state": {
+            "dtype": "float32",
+            "shape": (6,),
+            "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3"]},
+        },
+        "observation.states.joint_state": {
+            "dtype": "float32",
+            "shape": (7,),
+            "names": {"motors": ["joint_0", "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]},
+        },
+        "observation.states.gripper_state": {
+            "dtype": "float32",
+            "shape": (2,),
+            "names": {"motors": ["gripper", "gripper"]},
+        },
+        "action": {
+            "dtype": "float32",
+            "shape": (7,),
+            "names": {"motors": ["x", "y", "z", "axis_angle1", "axis_angle2", "axis_angle3", "gripper"]},
+        },
+    }
+    tags = ["libero", "franka"]
 
-    from datatrove.utils.logging import logger
+    def __init__(self, src_paths: list[Path], output_path: Path):
+        super().__init__(output_path)
+        self.src_paths = src_paths
 
-    logger.remove()
-    logger.add(sys.stdout, level="INFO", colorize=True)
-    return logger
+    def load_tasks(self) -> list[ConversionTask]:
+        tasks = []
+        for src_path in self.src_paths:
+            for input_h5 in src_path.glob("*.hdf5"):
+                pattern1 = re.compile(r"_SCENE\d+_(.*?)_demo\.hdf5")
+                pattern2 = re.compile(r"(.*?)_demo\.hdf5")
 
+                match = pattern1.search(input_h5.name)
+                if match is None:
+                    match = pattern2.search(input_h5.name)
+                if match is None:
+                    continue
+                else:
+                    task_instruction = match.group(1).replace("_", " ")
 
-class SaveLerobotDataset(PipelineStep):
-    name = "Save Temp LerobotDataset"
-    type = "libero2lerobot"
+                tasks.append(
+                    ConversionTask(
+                        input_path=input_h5.resolve(),
+                        output_path=(
+                            self.temp_output_path
+                            / f"{src_path.name}"
+                            / input_h5.stem
+                        ).resolve(),
+                        local_repo_id=f"{input_h5.parent.name}/{input_h5.name}",
+                        metadata={"task": task_instruction},
+                    )
+                )
+        return tasks
 
-    def __init__(self, tasks: list[tuple[Path, Path, str]]):
-        super().__init__()
-        self.tasks = tasks
-
-    def run(self, data=None, rank: int = 0, world_size: int = 1):
-        logger = setup_logger()
-
-        input_h5, output_path, task_instruction = self.tasks[rank]
-
-        if output_path.exists():
-            shutil.rmtree(output_path)
-
-        dataset = LeRobotDataset.create(
-            repo_id=f"{input_h5.parent.name}/{input_h5.name}",
-            root=output_path,
-            fps=20,
-            robot_type="franka",
-            features=LIBERO_FEATURES,
-        )
-
-        logger.info(f"start processing for {input_h5}, saving to {output_path}")
-
-        raw_dataset = load_local_episodes(input_h5)
-        for episode_index, episode_data in enumerate(raw_dataset):
-            with self.track_time("saving episode"):
-                for frame_data in episode_data:
-                    frame_data["task"] = task_instruction
-                    dataset.add_frame(frame_data)
-                dataset.save_episode()
-                logger.info(f"process done for {dataset.repo_id}, episode {episode_index}, len {len(episode_data)}")
-
-
-def create_aggr_dataset(raw_dirs: list[Path], aggregated_dir: Path):
-    logger = setup_logger()
-
-    all_metadata = [LeRobotDatasetMetadata("", root=raw_dir) for raw_dir in raw_dirs]
-
-    fps, robot_type, features = validate_all_metadata(all_metadata)
-
-    if aggregated_dir.exists():
-        shutil.rmtree(aggregated_dir)
-
-    aggr_meta = LeRobotDatasetMetadata.create(
-        repo_id=f"{aggregated_dir.parent.name}/{aggregated_dir.name}",
-        root=aggregated_dir,
-        fps=fps,
-        robot_type=robot_type,
-        features=features,
-    )
-
-    video_keys = [key for key in features if features[key]["dtype"] == "video"]
-    unique_tasks = pd.concat([m.tasks for m in all_metadata]).index.unique()
-    aggr_meta.tasks = pd.DataFrame({"task_index": range(len(unique_tasks))}, index=unique_tasks)
-
-    meta_idx = {"chunk": 0, "file": 0}
-    data_idx = {"chunk": 0, "file": 0}
-    videos_idx = {key: {"chunk": 0, "file": 0, "latest_duration": 0, "episode_duration": 0} for key in video_keys}
-
-    aggr_meta.episodes = {}
-
-    for src_meta in tqdm(all_metadata, desc="Copy data and videos"):
-        videos_idx = aggregate_videos(
-            src_meta, aggr_meta, videos_idx, DEFAULT_VIDEO_FILE_SIZE_IN_MB, DEFAULT_CHUNK_SIZE
-        )
-        data_idx = aggregate_data(src_meta, aggr_meta, data_idx, DEFAULT_DATA_FILE_SIZE_IN_MB, DEFAULT_CHUNK_SIZE)
-
-        meta_idx = aggregate_metadata(src_meta, aggr_meta, meta_idx, data_idx, videos_idx)
-
-        aggr_meta.info["total_episodes"] += src_meta.total_episodes
-        aggr_meta.info["total_frames"] += src_meta.total_frames
-
-    logger.info("write tasks")
-    write_tasks(aggr_meta.tasks, aggr_meta.root)
-
-    logger.info("write info")
-    aggr_meta.info.update(
-        {
-            "total_tasks": len(aggr_meta.tasks),
-            "total_episodes": sum(m.total_episodes for m in all_metadata),
-            "total_frames": sum(m.total_frames for m in all_metadata),
-            "splits": {"train": f"0:{sum(m.total_episodes for m in all_metadata)}"},
-        }
-    )
-    write_info(aggr_meta.info, aggr_meta.root)
-
-    logger.info("write stats")
-    aggr_meta.stats = aggregate_stats([m.stats for m in all_metadata])
-    write_stats(aggr_meta.stats, aggr_meta.root)
-
-
-def delete_temp_data(temp_dirs: list[Path]):
-    logger = setup_logger()
-    logger.info("Delete temp data_dir")
-    for temp_dir in temp_dirs:
-        shutil.rmtree(temp_dir)
+    def load_subset(self, task: ConversionTask) -> Iterable[Sequence[dict]]:
+        input_h5 = task.input_path
+        task_instruction = task.metadata.get("task")
+        with File(input_h5, "r") as f:
+            for demo in f["data"].values():
+                demo_len = len(demo["obs/agentview_rgb"])
+                # (-1: open, 1: close) -> (0: close, 1: open)
+                action = np.array(demo["actions"])
+                action = np.concatenate(
+                    [
+                        action[:, :6],
+                        (1 - np.clip(action[:, -1], 0, 1))[:, None],
+                    ],
+                    axis=1,
+                )
+                state = np.concatenate(
+                    [
+                        np.array(demo["obs/ee_states"]),
+                        np.array(demo["obs/gripper_states"]),
+                    ],
+                    axis=1,
+                )
+                episode = {
+                    "observation.images.image": np.array(demo["obs/agentview_rgb"]),
+                    "observation.images.wrist_image": np.array(demo["obs/eye_in_hand_rgb"]),
+                    "observation.state": np.array(state, dtype=np.float32),
+                    "observation.states.ee_state": np.array(demo["obs/ee_states"], dtype=np.float32),
+                    "observation.states.joint_state": np.array(demo["obs/joint_states"], dtype=np.float32),
+                    "observation.states.gripper_state": np.array(demo["obs/gripper_states"], dtype=np.float32),
+                    "action": np.array(action, dtype=np.float32),
+                }
+                yield [{**{k: v[i] for k, v in episode.items()}, "task": task_instruction} for i in range(demo_len)]
 
 
 def main(
@@ -146,86 +131,25 @@ def main(
     cpus_per_task: int,
     tasks_per_job: int,
     workers: int,
-    resume_dir: Path = None,
+    resume_dir: Path | None = None,
     debug: bool = False,
-    repo_id: str = None,
+    repo_id: str | None = None,
     push_to_hub: bool = False,
 ):
-    tasks = []
-    pattern1 = re.compile(r"_SCENE\d+_(.*?)_demo\.hdf5")
-    pattern2 = re.compile(r"(.*?)_demo\.hdf5")
-    for src_path in src_paths:
-        for input_h5 in src_path.glob("*.hdf5"):
-            match = pattern1.search(input_h5.name)
-            if match is None:
-                match = pattern2.search(input_h5.name)
-                if match is None:
-                    continue
-            tasks.append(
-                (
-                    input_h5,
-                    (output_path / (src_path.name + "_temp") / input_h5.stem).resolve(),
-                    match.group(1).replace("_", " "),
-                )
-            )
-    if len(src_paths) > 1:
-        aggregate_output_path = output_path / (
-            "_".join([src_path.name for src_path in src_paths]) + "_aggregated_lerobot"
-        )
-    else:
-        aggregate_output_path = output_path / f"{src_paths[0].name}_lerobot"
-    aggregate_output_path = aggregate_output_path.resolve()
+    adapter = LiberoAdapter(src_paths, output_path)
 
-    if debug:
-        executor = "local"
-        workers = 1
-        tasks = tasks[:2]
-        push_to_hub = False
-
-    match executor:
-        case "local":
-            workers = os.cpu_count() // cpus_per_task if workers == -1 else workers
-            executor = LocalPipelineExecutor
-        case "ray":
-            runtime_env = RuntimeEnv(
-                env_vars={
-                    "HDF5_USE_FILE_LOCKING": "FALSE",
-                    "HF_DATASETS_DISABLE_PROGRESS_BARS": "TRUE",
-                    "SVT_LOG": "1",
-                },
-            )
-            ray.init(runtime_env=runtime_env)
-            executor = RayPipelineExecutor
-        case _:
-            raise ValueError(f"Executor {executor} not supported")
-
-    executor_config = {
-        "tasks": len(tasks),
-        "workers": workers,
-        **({"cpus_per_task": cpus_per_task, "tasks_per_job": tasks_per_job} if executor is RayPipelineExecutor else {}),
-    }
-
-    executor(pipeline=[SaveLerobotDataset(tasks)], **executor_config, logging_dir=resume_dir).run()
-    create_aggr_dataset([task[1] for task in tasks], aggregate_output_path)
-    delete_temp_data([task[1] for task in tasks])
-
-    for task in tasks:
-        shutil.rmtree(task[1].parent, ignore_errors=True)
-
-    if push_to_hub:
-        assert repo_id is not None
-        tags = ["LeRobot", "libero", "franka"]
-        tags.extend([src_path.name for src_path in src_paths])
-        LeRobotDataset(
-            repo_id=repo_id,
-            root=aggregate_output_path,
-        ).push_to_hub(
-            tags=tags,
-            private=False,
-            push_videos=True,
-            license="apache-2.0",
-            upload_large_folder=False,
-        )
+    run_converter(
+        adapter=adapter,
+        executor=executor,
+        cpus_per_task=cpus_per_task,
+        tasks_per_job=tasks_per_job,
+        workers=workers,
+        resume_dir=resume_dir,
+        debug=debug,
+        local_repo_id=repo_id,
+        hub_repo_id=repo_id,
+        push_to_hub=push_to_hub,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What does this PR do?

Adds a reusable `generic_converter` package for task-based dataset conversions into LeRobot format.

This includes:
- a `BaseAdapter` interface for dataset-specific task loading and episode loading
- shared conversion flow for local/Ray Datatrove execution
- temporary LeRobot dataset aggregation and cleanup
- optional Hub upload support
- README documentation for the current adapter contract

No GitHub issue is linked for this change.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that is the case).
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that is the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

Validation: Not run in this PR update.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
